### PR TITLE
fix idx

### DIFF
--- a/example_tracking_pool.py
+++ b/example_tracking_pool.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
                     kwds=dict(nturns=nturns, losses=True),
                 )
                 results.append(result)
-                tracked[idxproc] = True
+                tracked[idx] = True
             print(f"Block {idxblock} of {nblocks} launched", end="")
             for r in results:
                 r.wait()


### PR DESCRIPTION
Hi Elia,
this is a fix on the bug you found this morning.
`idx` should be ok now when indexing the `tracked` array.

o